### PR TITLE
Don't die if 'PATH' not in os.environ

### DIFF
--- a/pywin32.pth
+++ b/pywin32.pth
@@ -3,4 +3,4 @@ win32
 win32\lib
 Pythonwin
 
-import os;os.environ["PATH"]+=(';'+os.path.join(sitedir,"pywin32_system32")) if "pywin32_system32" not in os.environ["PATH"] else ''
+import os;os.environ["PATH"]=os.environ.get("PATH", "")+((os.pathsep+os.path.join(sitedir,"pywin32_system32")) if "pywin32_system32" not in os.environ.get("PATH", "") else '')


### PR DESCRIPTION
This happens when building some versions of Mercurial.